### PR TITLE
Don't check Telegraf package

### DIFF
--- a/decapod/discover.sls
+++ b/decapod/discover.sls
@@ -107,6 +107,6 @@ add telegraf repo:
 
 telegraf:
   pkg.installed
-
+    - skip_verify: True
 
 


### PR DESCRIPTION
Otherwise gets "E: There were unauthenticated packages and -y was used without --allow-unauthenticated"